### PR TITLE
ci: add harden-runner to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -5,6 +5,10 @@ jobs:
   go-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -20,6 +24,10 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     outputs:
       go: ${{ steps.go.outputs.any_changed }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -30,4 +34,8 @@ jobs:
       - ci-go
     if: '!failure()'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - run: echo "OK"


### PR DESCRIPTION
## Summary

- Add step-security/harden-runner v2.16.1 as the first step in all GitHub Actions workflow jobs
- Configured with egress-policy: audit to monitor outbound traffic
- Improves supply chain security for CI/CD pipelines

## References

- [StepSecurity Harden Runner](https://github.com/step-security/harden-runner)