### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-cms-api
+  namespace: reearth
+  description: Re:Earth CMS API client
+  annotations:
+    github.com/project-slug: reearth/reearth-cms-api
+  links:
+  - url: https://github.com/reearth/reearth-cms-api
+    title: GitHub
+    icon: github
+  tags:
+  - python
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cms


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-cms-api` (namespace `reearth`)
- **Owner:** `reearth/cms`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.